### PR TITLE
Add support for apple pay coupons.

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -35,6 +35,15 @@ import PassKit
         handler: @escaping (_ update: PKPaymentRequestShippingContactUpdate) -> Void
     )
 
+    /// Called when the user has entered a coupon code. You should validate the
+    /// coupon and must invoke the completion block with a PKPaymentRequestCouponCodeUpdate object.
+    @available(iOS 15.0, *)
+    @objc optional func applePayContext(
+        _ context: STPApplePayContext,
+        didChangeCouponCode couponCode: String,
+        handler completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
+    )
+
     /// Optionally configure additional information on your PKPaymentAuthorizationResult.
     /// This closure will be called after the PaymentIntent or SetupIntent is confirmed, but before
     /// the Apple Pay sheet has been closed.
@@ -305,11 +314,32 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
                 didSelectShippingContact:
                 handler:
             ))
-
-        return [
+        
+        var delegateToAppleDelegateMapping = [
             pk_didSelectShippingMethod: stp_didSelectShippingMethod,
             pk_didSelectShippingContact: stp_didSelectShippingContact,
         ]
+
+        if #available(iOS 15.0, *) {
+            // On iOS 15+, Apple Pay can now accept coupon codes directly, so we need to broker the
+            // new coupon delegate functions between the host app and Apple Pay.
+            let pk_didChangeCouponCode = #selector(
+                PKPaymentAuthorizationControllerDelegate.paymentAuthorizationController(
+                    _:
+                    didChangeCouponCode:
+                    handler:
+                ))
+            let stp_didChangeCouponCode = #selector(
+                _stpinternal_STPApplePayContextDelegateBase.applePayContext(
+                    _:
+                    didChangeCouponCode:
+                    handler:
+                ))
+
+            delegateToAppleDelegateMapping[pk_didChangeCouponCode] = stp_didChangeCouponCode
+        }
+
+        return delegateToAppleDelegateMapping
     }
 
     func _end() {
@@ -424,6 +454,22 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
                 ))
         ) ?? false {
             delegate?.applePayContext?(self, didSelectShippingContact: contact, handler: completion)
+        }
+    }
+
+    /// :nodoc:
+    @available(iOS 15.0, *)
+    @objc
+    public func paymentAuthorizationController(
+        _ controller: PKPaymentAuthorizationController,
+        didChangeCouponCode couponCode: String,
+        handler completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void) {
+
+        if delegate?.responds(
+            to: #selector(
+                _stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didChangeCouponCode:handler:))
+        ) ?? false {
+            delegate?.applePayContext?(self, didChangeCouponCode: couponCode, handler: completion)
         }
     }
 


### PR DESCRIPTION
## Summary
- Update the STPApplePayContextDelegate protocol to include an optional function for when the coupon code changes.
- Update the STPApplePayContext delegate mapping to include our new coupon delegate function.
- Add the paymentAuthorizationController delegate function to STPApplePayContext to broker coupon changes between Apple Pay and the host app.

## Motivation
Support adding coupon code directly in Apple Pay.

Feature Request: https://github.com/stripe/stripe-ios/issues/2278

## Testing
This was tested on device in iOS 15, 16 and 17.

## Changelog
- [Added] The ability to use coupon codes in the Apple Pay experience directly.
